### PR TITLE
.container .content CSS and .post-item HTML fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ hugo -t cocoa
 
 ## Usage
 
+#### config.toml
+
+Please see the sample [`config.toml`](https://github.com/nishanths/cocoa-hugo-theme/blob/master/exampleSite/config.toml) in `exampleSite/`.
+
 #### Creating Content
 
 * Posts should generally go under a `content/blog` directory. Typically you would run:
@@ -47,17 +51,13 @@ hugo -t cocoa
 hugo new blog/your-new-post.md
 ````
 
-(You may need to set `draft = false` in the new post's front matter for it to appear on your site.)
+You may need to set `draft = false` in the new post's front matter for it to appear on your site.
 
 * Fixed pages such as an About page should preferably go under a `content/fixed` or be present at the root of the `contents` directory.
 
 ````
 $ hugo new fixed/about.md
 ````
-
-#### config.toml
-
-Please see the sample [`config.toml`](https://github.com/nishanths/cocoa-hugo-theme/blob/master/exampleSite/config.toml) in `exampleSite/`.
 
 #### Example site
 

--- a/dev/less/main.less
+++ b/dev/less/main.less
@@ -286,6 +286,8 @@ section.icons {
     }
 
     .content {
+        width: auto;
+
         a {
             margin-left: 6px;
             margin-right: 6px;
@@ -576,7 +578,7 @@ img {
 }
 
 img.profile {
-  min-width:100%;
+    min-width:100%;
 }
 
 @media (min-width: @wide-1-breakpoint) {

--- a/layouts/partials/li.html
+++ b/layouts/partials/li.html
@@ -1,4 +1,4 @@
 <li class="post-item">
-    <div class="meta">{{ .Date.Format .Site.Params.DateForm }}</div>
-    <a href="{{ .Permalink }}"><div>{{ .Title }}</div></a>
+    <span class="meta">{{ .Date.Format .Site.Params.DateForm }}</span>
+    <a href="{{ .Permalink }}"><span>{{ .Title }}</span></a>
 </li>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -274,6 +274,9 @@ section.icons .container {
   -ms-justify-content: center;
   justify-content: center;
 }
+section.icons .content {
+  width: auto;
+}
 section.icons .content a {
   margin-left: 6px;
   margin-right: 6px;


### PR DESCRIPTION
- .container .content for icons should not be 100%
  to help with centering.
- Use span for .post-item internals, otherwise Firefox
  messes up at smaller screen width with the list bullet
  and title on separate lines.
- README wording

Fix #17
