### PR TITLE
layouts: restore compatibility with Hugo < 0.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ See this [Imgur album](http://imgur.com/a/skabh) or the [`images/`](https://gith
 
 > v0.2.0
 
-* Added Disqus support. To enable Disqus, add `disqusShortname = "XYZ"` to `config.toml`. More details: <http://gohugo.io/extras/comments/>.
+* Added Disqus support. To enable Disqus, add `disqusshortname = "XYZ"` to `config.toml`. More details: <http://gohugo.io/extras/comments/>.
 * In the posts list, replaced date with bullets at smaller screen widths.
 
 > v0.1.0

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ hugo -t cocoa
 
 Please see the sample [`config.toml`](https://github.com/nishanths/cocoa-hugo-theme/blob/master/exampleSite/config.toml) in `exampleSite/`.
 
+Note that if you already use cocoa but have updated to Hugo 0.18, you must lowercase every params of your existing `config.toml`. (like in the sample)
+
 #### Creating Content
 
 * Posts should generally go under a `content/blog` directory. Typically you would run:

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -8,7 +8,7 @@ publishdir = "public"
 author = "Arthur Dent"
 title = "Arthur Dent"
 pygmentsuseclasses = true
-disqusShortname = "cocoaexamplesite" # Comment out to disable Disqus.
+disqusshortname = "cocoaexamplesite" # Comment out to disable Disqus.
 pluralizelisttitles = false
 
 [permalinks]
@@ -16,21 +16,21 @@ fixed = ":title/"
 blog = "blog/:slug/"
 
 [params]
-Author = "Arthur Dent"
-# Gravatar = "" # do not use in the same time as Avatar
-# Avatar = "" # path to image in static dir e.g img/avatar.png (do not use in the same time as Gravatar)
-CacheBuster = true
-DateForm = "Jan 2, 2006"
-DateFormFull = "Mon Jan 2 2006 15:04:05 MST"
-Description = "Don't panic"
-Email = "you@example.space"
-FaviconFile = "img/leaf.ico"
-GATracker = "XYZ"
-GitHub = "//github.com/you"
-HighlightJS = true
-Initials = "ad" # Displayed on single post page; DEPRECATED in v0.3.0.
-Lang = "en"
-LinkedIn = "//linkedin.com/in/you"
-Twitter = "//twitter.com/you"
+author = "Arthur Dent"
+# gravatar = "" # do not use in the same time as Avatar
+# avatar = "" # path to image in static dir e.g img/avatar.png (do not use in the same time as Gravatar)
+cachebuster = true
+dateform = "Jan 2, 2006"
+dateformfull = "Mon Jan 2 2006 15:04:05 MST"
+description = "Don't panic"
+email = "you@example.space"
+faviconfile = "img/leaf.ico"
+gatracker = "XYZ"
+github = "//github.com/you"
+highlightjs = true
+initials = "ad" # Displayed on single post page; DEPRECATED in v0.3.0.
+lang = "en"
+linkedin = "//linkedin.com/in/you"
+twitter = "//twitter.com/you"
 
-ExtraCssFiles = [ "/css/override.css" ] # In your `static/css`, add/remove files as necessary.
+extracssfiles = [ "/css/override.css" ] # In your `static/css`, add/remove files as necessary.

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -9,7 +9,7 @@
                     <div class="initials"><a href="{{ .Site.BaseURL }}">{{ .Site.Params.Initials }}</a></div>
                 </div>
                 <div class="meta">
-                    <div class="date" title="{{ .Date.Format (.Site.Param "DateFormFull") }}">{{ .Date.Format (.Site.Param "DateForm") }}</div>
+                    <div class="date" title="{{ .Date.Format .Site.Params.dateformfull }}">{{ .Date.Format .Site.Params.dateform }}</div>
                     <div class="reading-time"><div class="middot"></div>{{ if eq 1 .ReadingTime }}{{ .ReadingTime }} minute read{{ else }}{{ .ReadingTime }} minutes read{{ end }}</div>
                 </div>
             </div>

--- a/layouts/partials/footer_scripts.html
+++ b/layouts/partials/footer_scripts.html
@@ -1,18 +1,18 @@
 <!-- Google Analytics -->
-{{ if .Site.Param "GATracker" }}
+{{ if .Site.Params.gatracker }}
 <script type="text/javascript">
 var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 </script>
 <script type="text/javascript">
 try {
-    var pageTracker = _gat._getTracker("{{ .Site.Param "GATracker" }}");
+    var pageTracker = _gat._getTracker("{{ .Site.Params.gatracker }}");
     pageTracker._trackPageview();
 } catch(err) {}
 </script>
 {{ end }}
 
-{{ if .Site.Param "HighlightJS" }}
+{{ if .Site.Params.highlightjs }}
   <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
 
   <script type="text/javascript">

--- a/layouts/partials/head_includes.html
+++ b/layouts/partials/head_includes.html
@@ -10,18 +10,18 @@
 
 <!-- CSS -->
 
-{{ if (.Site.Param "HighlightJS") }}
+{{ if .Site.Params.highlightjs }}
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/default.min.css">
 {{ end }}
 
 
-{{ if eq true (.Site.Param "CacheBuster") }}
+{{ if eq true .Site.Params.cachebuster }}
 
 <link rel="stylesheet" href="/css/reset.css">
 <link rel="stylesheet" href="/css/pygments.css">
 <link rel="stylesheet" href="/css/main.css">
 
-{{range (.Site.Param "ExtraCssFiles")}}
+{{range .Site.Params.extracssfiles}}
     <link rel="stylesheet" href="{{.}}">
 {{end}}
 
@@ -31,7 +31,7 @@
 <link rel="stylesheet" href="/css/pygments.css?{{ .Now.Unix }}">
 <link rel="stylesheet" href="/css/main.css?{{ .Now.Unix }}">
 
-{{range (.Site.Param "ExtraCssFiles")}}
+{{range .Site.Params.extracssfiles}}
     <link rel="stylesheet" href="{{.}}?{{ .Now.Unix }}">
 {{end}}
 
@@ -39,8 +39,8 @@
 
 <!-- Icon -->
 <link rel="shortcut icon"
-{{ if (.Site.Param "FaviconFile") }}
-    href="/{{ .Site.Param "FaviconFile" }}"
+{{ if .Site.Params.faviconfile }}
+    href="/{{ .Site.Params.faviconfile }}"
 {{ else }}
     href="/img/favicon.ico"
 {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,17 +3,17 @@
 
 {{ partial "head.html" . }}
 
-<body lang="{{ .Site.Param "Lang" }}">
+<body lang="{{ .Site.Params.lang }}">
 
 <section class="header"> 
     <div class="container">
         <div class="content">
-            {{ if .Site.Param "Gravatar" }}
-              <a href="/"><img class="avatar" src="https://gravatar.com/avatar/{{ .Site.Param "Gravatar" }}?s=50" /></a>
-            {{ else if .Site.Param "Avatar" }}
-              <a href="/"><img class="avatar" src="/{{ .Site.Param "Avatar" }}" /></a>
+            {{ if .Site.Params.gravatar }}
+              <a href="/"><img class="avatar" src="https://gravatar.com/avatar/{{ .Site.Params.gravatar }}?s=50" /></a>
+            {{ else if .Site.Params.avatar }}
+              <a href="/"><img class="avatar" src="/{{ .Site.Params.avatar }}" /></a>
             {{ end }}
-            <a href="/"><div class="name">{{ .Site.Param "Author" }}</div></a>
+            <a href="/"><div class="name">{{ .Site.Params.author }}</div></a>
             <nav>
                 <ul>
                     <a href="/blog/"><li>Blog</li></a>
@@ -29,38 +29,38 @@
     <div class="container">
         <div class="content">
 
-        {{ if .Site.Param "GitHub" }}
-            <a href="{{ .Site.Param "GitHub" }}" target="_blank">
+        {{ if .Site.Params.github }}
+            <a href="{{ .Site.Params.github }}" target="_blank">
                 <i class="icon ion-social-github"></i>
             </a>
         {{ end }}
         
-        {{ if .Site.Param "Twitter" }}
-            <a href="{{ .Site.Param "Twitter" }}" target="_blank">
+        {{ if .Site.Params.twitter }}
+            <a href="{{ .Site.Params.twitter }}" target="_blank">
                 <i class="icon ion-social-twitter"></i>
             </a>
         {{ end }}
 
-        {{ if .Site.Param "LinkedIn" }}
-            <a href="{{ .Site.Param "LinkedIn" }}" target="_blank">
+        {{ if .Site.Params.linkedin }}
+            <a href="{{ .Site.Params.linkedin }}" target="_blank">
                 <i class="icon ion-social-linkedin"></i>
             </a>
         {{ end }}
 
-        {{ if .Site.Param "Facebook" }}
-            <a href="{{ .Site.Param "Facebook" }}" target="_blank">
+        {{ if .Site.Params.facebook }}
+            <a href="{{ .Site.Params.facebook }}" target="_blank">
                 <i class="icon ion-social-facebook larger"></i>
             </a>
         {{ end }}
 
-        {{ if .Site.Param "SoundCloud" }}
-            <a href="{{ .Site.Param "SoundCloud" }}" target="_blank">
+        {{ if .Site.Params.soundcloud }}
+            <a href="{{ .Site.Params.soundcloud }}" target="_blank">
                 <i class="icon ion-ios-musical-notes larger"></i>
             </a>
         {{ end }}
 
-        {{ if .Site.Param "Email" }}
-            <a href="mailto:{{ .Site.Param "Email" }}">
+        {{ if .Site.Params.email }}
+            <a href="mailto:{{ .Site.Params.email }}">
                 <i class="icon ion-ios-email larger"></i>
             </a>
         {{ end }}

--- a/layouts/partials/li.html
+++ b/layouts/partials/li.html
@@ -1,4 +1,4 @@
 <li class="post-item">
-    <span class="meta">{{ .Date.Format (.Site.Param "DateForm") }}</span>
+    <span class="meta">{{ .Date.Format .Site.Params.dateform }}</span>
     <a href="{{ .Permalink }}"><span>{{ .Title }}</span></a>
 </li>

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -3,4 +3,4 @@
 <meta name="HandheldFriendly" content="True">
 <meta name="MobileOptimized" content="320">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{{ if .Site.Param "Description" }}<meta name="description" content="{{ .Site.Param "Description" }}">{{ end }}
+{{ if .Site.Params.description }}<meta name="description" content="{{ .Site.Params.description }}">{{ end }}


### PR DESCRIPTION
Due to recent changes in hugo, themes can't both support < 0.18 and 0.18 without having all their Params fields to lowercase.  (see https://github.com/nishanths/cocoa-hugo-theme/issues/27 for more info)

This PR does that and I submit it instead of directly pushing to `master` to let you validate that it's something you want @nishanths 

It you don't, we should also revert my previous PRs which were only working with 0.18

PR tested on Hugo 0.16, 0.17 and current 0.18