### PR TITLE
Support additional languages for highlight.js

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -28,6 +28,7 @@ faviconfile = "img/leaf.ico"
 gatracker = "XYZ"
 github = "//github.com/you"
 highlightjs = true
+# highlightjslanguages = ["go"] # additional languages not included in the "common" set
 initials = "ad" # Displayed on single post page; DEPRECATED in v0.3.0.
 lang = "en"
 linkedin = "//linkedin.com/in/you"

--- a/layouts/partials/footer_scripts.html
+++ b/layouts/partials/footer_scripts.html
@@ -13,7 +13,10 @@ try {
 {{ end }}
 
 {{ if .Site.Params.highlightjs }}
-  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/highlight.min.js"></script>
+  {{ range .Site.Params.highlightjslanguages }}
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/languages/{{.}}.min.js"></script>
+  {{ end }}
 
   <script type="text/javascript">
     hljs.initHighlightingOnLoad();

--- a/layouts/partials/head_includes.html
+++ b/layouts/partials/head_includes.html
@@ -11,7 +11,7 @@
 <!-- CSS -->
 
 {{ if .Site.Params.highlightjs }}
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/default.min.css">
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/styles/default.min.css">
 {{ end }}
 
 


### PR DESCRIPTION
highlight.min.js only includes 22 commonly used languages. E.g. Go and
Rust are not part of that set. This change allows users to add the JS
for additional languages via a config option.

I've also updated the library to the newest version.