### PR TITLE
Added forcehttps param

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -30,6 +30,7 @@ lang         = "en"
 linkedin     = "//linkedin.com/in/you"
 twitter      = "//twitter.com/you"
 selfIntro    = "" # appears in the site header when set to a non-empty string
+forcehttps   = true # use a script to detect whether visitors should be redirected to https
 
 # gravatar             = ""                # do not use in the same time as avatar
 avatar                 = "img/profile.png" # path to image in static dir e.g img/avatar.png (do not use in the same time as gravatar)

--- a/layouts/partials/head_includes.html
+++ b/layouts/partials/head_includes.html
@@ -1,5 +1,6 @@
 <!-- HTTPS -->
 
+{{ if .Site.Params.forcehttps }}
 <script type="text/javascript">
     var baseURL = '{{ .Site.BaseURL }}';
     var host = baseURL.substring(0, baseURL.length - 1).replace(/\//g, '');
@@ -7,6 +8,7 @@
         window.location.protocol = 'https:';
     }
 </script>
+{{ end }}
 
 <!-- CSS -->
 


### PR DESCRIPTION
Users may have HTTPS redirection or termination through their HTTP server, making the client-side check redundant. This changeset makes the client-side HTTPS check optional with a new site parameter: `forcehttps`.