### PR TITLE
update config params

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -17,26 +17,25 @@ fixed = ":title/"
 blog  = "blog/:slug/"
 
 [params]
-author       = "Arthur Dent"
-cachebuster  = true # add the current unix timestamp in query string for cache busting css assets
-dateform     = "Jan 2, 2006"
-dateformfull = "Mon Jan 2 2006 15:04:05 MST"
-description  = "Don't panic"
-email        = "you@example.space"
-faviconfile  = "img/leaf.ico"
-github       = "//github.com/you"
-highlightjs  = true
-lang         = "en"
-linkedin     = "//linkedin.com/in/you"
-twitter      = "//twitter.com/you"
-selfIntro    = "" # appears in the site header when set to a non-empty string
-forcehttps   = true # use a script to detect whether visitors should be redirected to https
+author                 = "Arthur Dent"
+cachebuster            = true                          # add the current unix timestamp in query string for cache busting css assets
+dateform               = "Jan 2, 2006"
+dateformfull           = "Mon Jan 2 2006 15:04:05 MST"
+description            = "Don't panic"
+email                  = "you@example.space"
+extracssfiles          = [ "/css/override.css" ]       # In your `static` directory, add/remove files as necessary.
+faviconfile            = "img/leaf.ico"
+github                 = "//github.com/you"
+highlightjs            = true
+lang                   = "en"
+linkedin               = "//linkedin.com/in/you"
+noshowreadtime         = false                         # if true, don't show "<x> minutes read" in posts
+selfintro              = ""                            # appears in the site header when set to a non-empty string
+twitter                = "//twitter.com/you"
+# highlightjslanguages = ["go"]                        # additional languages not included in the "common" set
 
-# gravatar             = ""                # do not use in the same time as avatar
 avatar                 = "img/profile.png" # path to image in static dir e.g img/avatar.png (do not use in the same time as gravatar)
-# highlightjslanguages = ["go"]            # additional languages not included in the "common" set
-
-extracssfiles = [ "/css/override.css" ] # In your `static` directory, add/remove files as necessary.
+# gravatar             = ""                # do not use in the same time as avatar
 
 # The following are DEPRECATED.
 gatracker              = "XYZ" # use googleAnalytics instead

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -9,8 +9,14 @@
                     <div class="initials"><a href="{{ .Site.BaseURL }}">{{ .Site.Params.Initials }}</a></div>
                 </div>
                 <div class="meta">
-                    <div class="date" title="{{ .Date.Format .Site.Params.dateformfull }}">{{ .Date.Format .Site.Params.dateform }}</div>
+                    {{ if and .Site.Params.dateformfull .Site.Params.dateform }}
+                    <div class="date" title='{{ .Date.Format .Site.Params.dateformfull }}'>{{ .Date.Format .Site.Params.dateform }}</div>
+                    {{ else }}
+                    <div class="date" title='{{ .Date.Format "Mon Jan 2 2006 15:04:05 MST" }}'>{{ .Date.Format "Jan 2, 2006" }}</div>
+                    {{ end }}
+                    {{ if not .Site.Params.noshowreadtime }}
                     <div class="reading-time"><div class="middot"></div>{{ if eq 1 .ReadingTime }}{{ .ReadingTime }} minute read{{ else }}{{ .ReadingTime }} minutes read{{ end }}</div>
+                    {{ end }}
                 </div>
             </div>
             <div class="markdown">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,8 +14,8 @@
               <a href="/"><img class="avatar" src="/{{ .Site.Params.avatar }}" /></a>
             {{ end }}
             <a href="/"><div class="name">{{ .Site.Params.author }}</div></a>
-            {{ if .Site.Params.selfIntro }}
-              <h3 class="self-intro">{{ .Site.Params.selfIntro }}</h3>
+            {{ if .Site.Params.selfintro }}
+              <h3 class="self-intro">{{ .Site.Params.selfintro }}</h3>
             {{ end }}
             <nav>
                 <ul>

--- a/layouts/partials/li.html
+++ b/layouts/partials/li.html
@@ -1,4 +1,8 @@
 <li class="post-item">
-    <span class="meta">{{ .Date.Format .Site.Params.dateform }}</span>
+    {{ if .Site.Params.dateform }}
+    <span class="meta"><time datetime='{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}'>{{ .Date.Format .Site.Params.dateform }}</time></span>
+    {{ else }}
+    <span class="meta"><time datetime='{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}'>{{ .Date.Format "Jan 2, 2006" }}</time></span>
+    {{ end }}
     <a href="{{ .Permalink }}"><span>{{ .Title }}</span></a>
 </li>


### PR DESCRIPTION
Clean up config.toml alignment.

Also, changes to params in config.toml:

* make `dateform` and `dateformfull` optional (doesn't crash if not present; no user facing change)
* add new param: `noshowreadtime` (no user-facing change if not present currently)
* lowercase `selfIntro` to `selfintro` (requires users to lowercase in config.toml)