### PR TITLE
Accept content and frontmatter for any page

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,6 +2,11 @@
 <section class="main">
     <div class="container">
         <div class="content">
+            {{ if .Content }}
+                <div class="markdown">
+                    {{ .Content }}
+                </div>
+            {{ end }}
             <div class="page-heading">Blog</div>
             <ul>
                 {{ range .Data.Pages.ByPublishDate }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,6 +2,11 @@
 <section class="main">
     <div class="container">
         <div class="content">
+            {{ if .Content }}
+                <div class="markdown">
+                    {{ .Content }}
+                </div>
+            {{ end }}
             <div class="page-heading">Blog</div>
             <ul>
             {{ range .Data.Pages.ByPublishDate }}


### PR DESCRIPTION
Starting with Hugo v0.18, users can add content and frontmatter to any
page, including Home and any list pages, by placing a _index.md file in
the right directory. This requires explicit support in the theme.

Please see https://gohugo.io/content/using-index-md/ for details.