### PR TITLE
Fix typo in markdown.less (em -> rem)

### DIFF
--- a/dev/less/markdown.less
+++ b/dev/less/markdown.less
@@ -24,7 +24,7 @@ h2 {
 }
 
 h3 {
-    font-size: 1em;
+    font-size: 1rem;
     margin-bottom: 1rem;
 }
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -588,7 +588,7 @@ section.main .content .markdown h2 {
   margin-bottom: 1.5rem;
 }
 section.main .content .markdown h3 {
-  font-size: 1em;
+  font-size: 1rem;
   margin-bottom: 1rem;
 }
 section.main .content .markdown h4,


### PR DESCRIPTION
Addresses GitHub issue #63.