### PR TITLE
Fix deprecation warning with Hugo 0.19

### DIFF
--- a/layouts/partials/head_includes.html
+++ b/layouts/partials/head_includes.html
@@ -22,7 +22,7 @@
 
 {{ if .Site.Params.cachebuster }}
 
-    {{ $t := .Now.Unix }}
+    {{ $t := now }}
     <link rel="stylesheet" href="/css/reset.css?t={{$t}}">
     <link rel="stylesheet" href="/css/pygments.css?t={{$t}}">
     <link rel="stylesheet" href="/css/main.css?t={{$t}}">


### PR DESCRIPTION
Hugo 0.19 warns that .Page.Now should be replace with 'now':

    WARNING: Page's Now is deprecated and will be removed in a future release. Use now (the template func).