### PR TITLE
Add template for Open Graph meta tags for Twitter and others

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -5,3 +5,5 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="referrer" content="no-referrer">
 {{ if .Site.Params.description }}<meta name="description" content="{{ .Site.Params.description }}">{{ end }}
+
+{{ template "_internal/opengraph.html" . }}


### PR DESCRIPTION
This makes Twitter and others show a nice card for blog posts with the
title (and the description on web).

Adds the following meta tags to pages, for example a blog post:

```html
<meta property="og:title" content="Page title" />
<meta property="og:description" content="Page description" />
<meta property="og:type" content="article" />
<meta property="og:url" content="canonical URL of the post" />
<meta property="article:published_time" content="2017-03-30T10:00:00&#43;11:00"/>
<meta property="article:modified_time" content="2017-03-30T10:00:00&#43;11:00"/>
```