### PR TITLE
Fix links to i18n screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Most features are optional and can be individually enabled/disabled in your [`co
 
 ### Switch between languages
 
-![german screenshot](https://raw.githubusercontent.com/lpancescu/cocoa-hugo-theme/i18n-flags/scr.de-fullpage.png) ![english screenshot](https://raw.githubusercontent.com/lpancescu/cocoa-hugo-theme/i18n-flags/scr.en-fullpage.png)
+![german screenshot](https://raw.githubusercontent.com/lpancescu/cocoa-hugo-theme/master/scr.de-fullpage.png) ![english screenshot](https://raw.githubusercontent.com/lpancescu/cocoa-hugo-theme/master/scr.en-fullpage.png)
 
 ## Table of Contents
 


### PR DESCRIPTION
I had originally linked to my i18n-flags branch, which doesn't exist any more.