### PR TITLE
Make gravatar look nice on high-resolution screens (retina)

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -9,7 +9,7 @@
     <div class="container">
         <div class="content">
             {{ if .Site.Params.gravatar }}
-            <a {{ printf "href=%q" ("/" | relLangURL) | safeHTMLAttr }}><img class="avatar" src="https://gravatar.com/avatar/{{ .Site.Params.gravatar }}?s=50" /></a>
+            <a {{ printf "href=%q" ("/" | relLangURL) | safeHTMLAttr }}><img class="avatar" src="https://gravatar.com/avatar/{{ .Site.Params.gravatar }}?s=100" /></a>
             {{ else if .Site.Params.avatar }}
             <a {{ printf "href=%q" ("/" | relLangURL) | safeHTMLAttr }}><img class="avatar" src="/{{ .Site.Params.avatar }}" /></a>
             {{ end }}


### PR DESCRIPTION
Double the resolution that we request from gravatar. The CSS sets
max-width to 50px, so it should not be a bigger image, just a better
resolution.