### PR TITLE
Fix blog index not showing a heading

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -2,6 +2,9 @@
 - id: latestPosts
   translation: "Die aktuelsten Artikeln"
 
+- id: blogHeading
+  translation: "Blog"
+
 - id: pageNotFound
   translation: "Sorry, this page does not exist."
 
@@ -11,7 +14,7 @@
 - id: readingTime
   translation:
     one: "Eine Minute Lesezeit"
-    other: "{{ .Count }} minutes read"
+    other: "{{ .Count }} Minuten Lesezeit"
 
 - id: backToPosts
   translation: "Zurück zum Artikelnverzeichnis"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -2,6 +2,9 @@
 - id: latestPosts
   translation: "Latest Posts"
 
+- id: blogHeading
+  translation: "Blog"
+
 - id: pageNotFound
   translation: "Sorry, this page does not exist."
 


### PR DESCRIPTION
The blogHeading string was missing from the included i18n files.