### PR TITLE
remove html5shiv

### DIFF
--- a/layouts/partials/head_includes.html
+++ b/layouts/partials/head_includes.html
@@ -54,7 +54,3 @@
 {{ if .RSSLink }}
   <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
 {{ end }}
-
-{{ `<!--[if lt IE 9]>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
-<![endif]-->` | safeHTML }}

--- a/layouts/partials/head_includes.html
+++ b/layouts/partials/head_includes.html
@@ -55,6 +55,6 @@
   <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
 {{ end }}
 
-<!--[if lt IE 9]>
-    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-<![endif]-->
+{{ `<!--[if lt IE 9]>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
+<![endif]-->` | safeHTML }}


### PR DESCRIPTION
This PR removes html5shiv in header. 
https://github.com/nishanths/cocoa-hugo-theme/pull/81#issuecomment-298675702

----

~~This PR makes html5shiv appears in header correctly.~~
> By default, Go Templates remove HTML comments from output.
http://gohugo.io/templates/go-templates/#internet-explorer-conditional-comments-using-pipes