### PR TITLE
Fix ordered list to show numbers instead of bullets

### DIFF
--- a/dev/less/main.less
+++ b/dev/less/main.less
@@ -32,3 +32,20 @@
 @import 'util';
 @import 'site';
 @import 'markdown';
+
+section.main .content .markdown ul {
+  list-style-type: disc;
+  list-style-position: outside;
+  margin-bottom: 1.25rem;
+}
+section.main .content .markdown ol {
+  list-style-type: decimal;
+ }
+
+section.main .content .markdown ol {
+ list-style-type: decimal;
+   margin-bottom: 1.25rem;
+ }
+  section.main .content .markdown li {
+   list-style-position: inside;
+ }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -670,10 +670,15 @@ section.main .content .markdown dd {
   margin-bottom: .5rem;
 }
 section.main .content .markdown ul {
+  list-style-type: disc;
+  list-style-position: outside;
+  margin-bottom: 1.25rem;
+}
+section.main .content .markdown ol {
+  list-style-type: decimal;
   margin-bottom: 1.25rem;
 }
 section.main .content .markdown li {
-  list-style-type: disc;
   list-style-position: inside;
 }
 section.main .content .markdown em {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -670,15 +670,10 @@ section.main .content .markdown dd {
   margin-bottom: .5rem;
 }
 section.main .content .markdown ul {
-  list-style-type: disc;
-  list-style-position: outside;
-  margin-bottom: 1.25rem;
-}
-section.main .content .markdown ol {
-  list-style-type: decimal;
   margin-bottom: 1.25rem;
 }
 section.main .content .markdown li {
+  list-style-type: disc;
   list-style-position: inside;
 }
 section.main .content .markdown em {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -733,3 +733,18 @@ section.main .content .markdown tbody tr:nth-child(odd) td,
 section.main .content .markdown tbody tr:nth-child(odd) th {
   background-color: #f7f7f7;
 }
+section.main .content .markdown ul {
+  list-style-type: disc;
+  list-style-position: outside;
+  margin-bottom: 1.25rem;
+}
+section.main .content .markdown ol {
+  list-style-type: decimal;
+}
+section.main .content .markdown ol {
+  list-style-type: decimal;
+  margin-bottom: 1.25rem;
+}
+section.main .content .markdown li {
+  list-style-position: inside;
+}


### PR DESCRIPTION
When I write in Markdown:
```
1. One
2. Two 
3. Three
```

It gets rendered as:
- One
- Two 
- Three

I changed the CSS so that ordered lists would show numbers instead of bullets.