### PR TITLE
Integrate tracking with Piwik

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A consistent and responsive [Hugo](http://gohugo.io) [theme](https://github.com/
 * Optimized SVG icons (by @robinst)
 * Cache busting
 * Google Analytics
+* Piwik
 ```
 
 Most features are optional and can be individually enabled/disabled in your [`config.toml`](https://github.com/nishanths/cocoa-hugo-theme/blob/master/exampleSite/config.toml).

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -57,6 +57,10 @@ mastodon               = "//example.com/@you"
 # highlightjslanguages = ["go"]                        # additional languages not included in the "common" set
 # highlightjsStyle     = "darcula"
 
+piwik				   = false                         # If true, Piwik integration is enabled
+# piwik_url            = "//www.example.com/piwik/"    # URL to your Piwik installation. Must End with a slash
+# piwik_id			   = 2                             # Id of your site in Piwik
+
 avatar                 = "img/profile.png" # path to image in static dir e.g img/avatar.png (do not use in the same time as gravatar)
 # gravatar             = ""                # do not use in the same time as avatar
 

--- a/layouts/partials/footer_scripts.html
+++ b/layouts/partials/footer_scripts.html
@@ -11,3 +11,21 @@
     hljs.initHighlightingOnLoad();
   </script>
 {{ end }}
+
+{{ if .Site.Params.piwik }}
+<!-- Piwik -->
+<script type="text/javascript">
+    var _paq = _paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+        var u="{{ .Site.Params.piwik_url }}";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', '{{ .Site.Params.piwik_id }}']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+    })();
+</script>
+<!-- End Piwik Code -->
+{{ end }}


### PR DESCRIPTION
- Add new config variables:
  piwik: If set to true, Piwik tracking is enabled
  piwik_url: URL to your Piwik installation
  piwik_id: Id of the site in Piwik

This closes https://github.com/nishanths/cocoa-hugo-theme/issues/21