### PR TITLE
Provide title and date in the default archetype

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,2 +1,6 @@
 +++
+title = "{{ replace .TranslationBaseName '-' ' ' | title }}"
+date = "{{ .Date }}"
+draft = true
+
 +++


### PR DESCRIPTION
This is required since Hugo 0.24 (see issue #98 on GitHub)