### PR TITLE
Add CSS class to "Back to Posts" link

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -22,7 +22,7 @@
             <div class="markdown">
                 {{ .Content }}
                 <br>
-		<p><a href="/blog/">{{ i18n "backToPosts" }}</a></p>
+		<p class="back-to-posts"><a href="/blog/">{{ i18n "backToPosts" }}</a></p>
             </div>
             <br>
             <div class="disqus">


### PR DESCRIPTION
This adds a `class="back-to-posts"` attribute to the "Back to Posts" link to facilitate styling of the "Back to Posts" link, if desired.