### PR TITLE
Sort blog posts from the latest to the oldest

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -15,7 +15,7 @@
                     {{ $.Scratch.Set "datespec" "2006" }}
                 {{ end }}
                 {{ if not ($.Scratch.Get "datespec") }}
-                    {{ range .Data.Pages.ByPublishDate }}
+                    {{ range .Data.Pages.ByPublishDate.Reverse }}
                     {{ partial "li.html" . }}
                     {{ end }}
                 {{ else }}
@@ -23,7 +23,7 @@
                         <li class="post-item no-bullet">
                             <span class="date">{{ .Key }}</span>
                         </li>
-                        {{ range .Pages.ByPublishDate }}
+                        {{ range .Pages.ByPublishDate.Reverse }}
                             {{ partial "li.html" . }}
                         {{ end }}
                     {{ end }}


### PR DESCRIPTION
In the Latest Posts section, the posts are ordered from the latest to the oldest. But if we click on Blog, the posts are in ascending order.
Following the same logic of https://github.com/nishanths/cocoa-hugo-theme/pull/110