### PR TITLE
Shows tags in blog page

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -22,7 +22,16 @@
             <div class="markdown">
                 {{ .Content }}
                 <br>
-		<p class="back-to-posts"><a href="/blog/">{{ i18n "backToPosts" }}</a></p>
+                {{ if .Params.tags }}
+                  <div class="tags">
+                    <strong>Tags:</strong>
+                  {{range .Params.tags}}
+                    <a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}">{{ . }}</a>
+                  {{end}}
+                  </div>
+                  <br />
+                {{end}}
+                <p class="back-to-posts"><a href="/blog/">{{ i18n "backToPosts" }}</a></p>
             </div>
             <br>
             <div class="disqus">


### PR DESCRIPTION
Thanks for this cool theme! I would like to show tags for every blog posts at the end. I tweaked the theme a little bit to support it on my site. It looks like, 

![image](https://user-images.githubusercontent.com/4211715/38966943-5844de96-43a2-11e8-8e47-0e155b839fd3.png)

[Live Example](http://vishnubharathi.codes/blog/the-beginnings/)

Please let me know if I could improve the look and feel of the tags section.