### PR TITLE
Add support for highlightjs dark themes

### DIFF
--- a/dev/less/markdown.less
+++ b/dev/less/markdown.less
@@ -41,13 +41,13 @@ h4, h5, h6 {
 code, pre {
     font-family: @monospace-font-stack;
     font-size: 1rem;
-    background-color: @background-gray;
 }
 
-code {
+code:not(.hljs) {
     /* enclosed by single backtick (`) */
     padding: .15em .5em;
     border-radius: 2px;
+    background-color: @background-gray;
 }
 
 pre {
@@ -55,7 +55,6 @@ pre {
     display: block;
     margin-top: 1rem;
     margin-bottom: 2rem;
-    padding: 1rem;
     line-height: 1.5em;
     white-space: pre;
     white-space: pre-wrap;
@@ -65,7 +64,7 @@ pre {
 
 pre code {
     /* enclosed by 3 backticks (```) */
-    padding: 0;
+    padding: 1rem;
     font-size: 1rem;
 }
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -606,19 +606,18 @@ section.main .content .markdown code,
 section.main .content .markdown pre {
   font-family: 'Ubuntu Mono', 'Menlo', monospace;
   font-size: 1rem;
-  background-color: #f7f7f7;
 }
-section.main .content .markdown code {
+section.main .content .markdown code:not(.hljs) {
   /* enclosed by single backtick (`) */
-  padding: .15em .5em;
+  padding: 0.15em 0.5em;
   border-radius: 2px;
+  background-color: #f7f7f7;
 }
 section.main .content .markdown pre {
   /* Hugo specific: consider using the 'highlight' shortcode */
   display: block;
   margin-top: 1rem;
   margin-bottom: 2rem;
-  padding: 1rem;
   line-height: 1.5em;
   white-space: pre;
   white-space: pre-wrap;
@@ -627,7 +626,7 @@ section.main .content .markdown pre {
 }
 section.main .content .markdown pre code {
   /* enclosed by 3 backticks (```) */
-  padding: 0;
+  padding: 1rem;
   font-size: 1rem;
 }
 section.main .content .markdown a code {
@@ -652,7 +651,7 @@ section.main .content .markdown dt {
   font-weight: bold;
 }
 section.main .content .markdown dd {
-  margin-bottom: .5rem;
+  margin-bottom: 0.5rem;
 }
 section.main .content .markdown ul {
   margin-bottom: 1.25rem;
@@ -691,10 +690,10 @@ section.main .content .markdown abbr[title] {
   border-bottom: 1px dotted #808080;
 }
 section.main .content .markdown blockquote {
-  padding: .5rem 1rem;
-  margin: .8rem 0;
+  padding: 0.5rem 1rem;
+  margin: 0.8rem 0;
   color: #7a7a7a;
-  border-left: .25rem solid #e5e5e5;
+  border-left: 0.25rem solid #e5e5e5;
 }
 section.main .content .markdown blockquote p:last-child {
   margin-bottom: 0;
@@ -717,7 +716,7 @@ section.main .content .markdown table {
 }
 section.main .content .markdown td,
 section.main .content .markdown th {
-  padding: .25rem .5rem;
+  padding: 0.25rem 0.5rem;
   border: 1px solid #e5e5e5;
 }
 section.main .content .markdown tbody tr:nth-child(odd) td,


### PR DESCRIPTION
Dark themes such as `darcula` weren't being rendered properly. This commit fixes it by removing the `background-color` set on `pre` and `code` tags, except for single backticks `code` tags.

![before-after-cocoa](https://user-images.githubusercontent.com/34144667/46774823-b7007f00-ccda-11e8-95f5-8f4e3dbba158.png)
> Before and after

Fixes #94 