### PR TITLE
Add config setting for self hosted highlight.js files

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -59,6 +59,8 @@ mastodon               = "//example.com/@you"
 highlightjs            = true
 # highlightjslanguages = ["go"]                        # additional languages not included in the "common" set
 # highlightjsStyle     = "darcula"
+# highlightjs_url        = "/js/highlight.min.js"        # relative path to your self hosted highlight.js file 
+# highlightjs_css_url    = "css/default.min.css"         # relative path to your self hosted css config for highlight.js
 
 piwik                  = false                         # If true, Piwik integration is enabled
 # piwik_url            = "//www.example.com/piwik/"    # URL to your Piwik installation. Must End with a slash

--- a/layouts/partials/footer_scripts.html
+++ b/layouts/partials/footer_scripts.html
@@ -2,11 +2,14 @@
 {{ template "_internal/google_analytics_async.html" . }}
 
 {{ if .Site.Params.highlightjs }}
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/highlight.min.js"></script>
-  {{ range .Site.Params.highlightjslanguages }}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/languages/{{.}}.min.js"></script>
+  {{ if .Site.Params.highlightjs_url }}
+    <script src="{{ .Site.Params.highlightjs_url }}"></script>
+  {{ else }}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/highlight.min.js"></script>
+    {{ range .Site.Params.highlightjslanguages }}
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/languages/{{.}}.min.js"></script>
+    {{ end }}
   {{ end }}
-
   <script type="text/javascript">
     hljs.initHighlightingOnLoad();
   </script>

--- a/layouts/partials/head_includes.html
+++ b/layouts/partials/head_includes.html
@@ -13,7 +13,11 @@
 <!-- CSS -->
 
 {{ if .Site.Params.highlightjs }}
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/styles/{{ .Site.Params.highlightjsStyle | default "default" }}.min.css">
+  {{ if .Site.Params.highlightjs_css_url }}
+    <link rel="stylesheet" href="{{ .Site.Params.highlightjs_css_url }}">
+  {{ else }}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/styles/{{ .Site.Params.highlightjsStyle | default "default" }}.min.css">
+  {{ end }}
 {{ end }}
 
 <!-- Fonts and icon CSS -->


### PR DESCRIPTION
Due to privacy reasons, I want to reduce external dependencies to a minimum. Therefore, I added some config settings to use self hosted highlight.js files instead of loading these from cloudflare servers.

