### PR TITLE
Minimal fixes for syntax highlighting with rST sources

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -603,12 +603,14 @@ section.main .content .markdown h6 {
   letter-spacing: none;
 }
 section.main .content .markdown code,
-section.main .content .markdown pre {
+section.main .content .markdown pre,
+section.main .content p .literal {
   font-family: 'Ubuntu Mono', 'Menlo', monospace;
   font-size: 1rem;
   background-color: #f7f7f7;
 }
-section.main .content .markdown code {
+section.main .content .markdown code,
+section.main .content p .literal {
   /* enclosed by single backtick (`) */
   padding: .15em .5em;
   border-radius: 2px;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -624,6 +624,8 @@ section.main .content .markdown pre {
   white-space: pre-wrap;
   word-break: break-all;
   word-wrap: break-word;
+  overflow-x: auto;
+  white-space: pre;
 }
 section.main .content .markdown pre code {
   /* enclosed by 3 backticks (```) */

--- a/static/css/pygments.css
+++ b/static/css/pygments.css
@@ -1,268 +1,268 @@
 .hll {
   background-color: #ffffcc;
 }
-.c {
+.c, .comment {
   color: #999988;
   font-style: italic;
 }
 /* Comment */
-.err {
+.err, .error {
   color: #a61717;
   background-color: #e3d2d2;
 }
 /* Error */
-.k {
+.k, .keyword {
   color: #000000;
   font-weight: bold;
 }
 /* Keyword */
-.o {
+.o, .operator {
   color: #000000;
   font-weight: bold;
 }
 /* Operator */
-.cm {
+.cm, .comment.multiline {
   color: #999988;
   font-style: italic;
 }
 /* Comment.Multiline */
-.cp {
+.cp, .comment.preproc {
   color: #999999;
   font-weight: bold;
   font-style: italic;
 }
 /* Comment.Preproc */
-.c1 {
+.c1, .comment.single {
   color: #999988;
   font-style: italic;
 }
 /* Comment.Single */
-.cs {
+.cs, .comment.special {
   color: #999999;
   font-weight: bold;
   font-style: italic;
 }
 /* Comment.Special */
-.gd {
+.gd, .generic.deleted {
   color: #000000;
   background-color: #ffdddd;
 }
 /* Generic.Deleted */
-.ge {
+.ge, .generic.emph {
   color: #000000;
   font-style: italic;
 }
 /* Generic.Emph */
-.gr {
+.gr, .generic.error {
   color: #aa0000;
 }
 /* Generic.Error */
-.gh {
+.gh, .generic.heading {
   color: #999999;
 }
 /* Generic.Heading */
-.gi {
+.gi, .generic.inserted {
   color: #000000;
   background-color: #ddffdd;
 }
 /* Generic.Inserted */
-.go {
+.go, .generic.output {
   color: #888888;
 }
 /* Generic.Output */
-.gp {
+.gp, .generic.prompt {
   color: #555555;
 }
 /* Generic.Prompt */
-.gs {
+.gs, .generic.strong {
   font-weight: bold;
 }
 /* Generic.Strong */
-.gu {
+.gu, .generic.subheading {
   color: #aaaaaa;
 }
 /* Generic.Subheading */
-.gt {
+.gt, .generic.traceback {
   color: #aa0000;
 }
 /* Generic.Traceback */
-.kc {
+.kc, .keyword.constant {
   color: #000000;
   font-weight: bold;
 }
 /* Keyword.Constant */
-.kd {
+.kd, .keyword.declaration {
   color: #000000;
   font-weight: bold;
 }
 /* Keyword.Declaration */
-.kn {
+.kn, .keyword.namespace {
   color: #000000;
   font-weight: bold;
 }
 /* Keyword.Namespace */
-.kp {
+.kp, .keyword.pseudo {
   color: #000000;
   font-weight: bold;
 }
 /* Keyword.Pseudo */
-.kr {
+.kr, .keyword.reserved {
   color: #000000;
   font-weight: bold;
 }
 /* Keyword.Reserved */
-.kt {
+.kt, .keyword.type {
   color: #445588;
   font-weight: bold;
 }
 /* Keyword.Type */
-.m {
+.m, .literal.number {
   color: #009999;
 }
 /* Literal.Number */
-.s {
+.s, .literal.string {
   color: #d01040;
 }
 /* Literal.String */
-.na {
+.na, .name.attribute {
   color: #008080;
 }
 /* Name.Attribute */
-.nb {
+.nb, .name.builtin {
   color: #0086B3;
 }
 /* Name.Builtin */
-.nc {
+.nc, .name.class {
   color: #445588;
   font-weight: bold;
 }
 /* Name.Class */
-.no {
+.no, .name.constant {
   color: #008080;
 }
 /* Name.Constant */
-.nd {
+.nd, .name.decorator {
   color: #3c5d5d;
   font-weight: bold;
 }
 /* Name.Decorator */
-.ni {
+.ni, .name.entity {
   color: #800080;
 }
 /* Name.Entity */
-.ne {
+.ne, .name.exception {
   color: #990000;
   font-weight: bold;
 }
 /* Name.Exception */
-.nf {
+.nf, .name.function {
   color: #990000;
   font-weight: bold;
 }
 /* Name.Function */
-.nl {
+.nl, .name.label {
   color: #990000;
   font-weight: bold;
 }
 /* Name.Label */
-.nn {
+.nn, .name.namespace {
   color: #555555;
 }
 /* Name.Namespace */
-.nt {
+.nt, .name.tag {
   color: #000080;
 }
 /* Name.Tag */
-.nv {
+.nv, .name.variable {
   color: #008080;
 }
 /* Name.Variable */
-.ow {
+.ow, .operator.word {
   color: #000000;
   font-weight: bold;
 }
 /* Operator.Word */
-.w {
+.w, .text.whitespace {
   color: #bbbbbb;
 }
 /* Text.Whitespace */
-.mf {
+.mf, .literal.number.float {
   color: #009999;
 }
 /* Literal.Number.Float */
-.mh {
+.mh, .literal.number.hex {
   color: #009999;
 }
 /* Literal.Number.Hex */
-.mi {
+.mi, .literal.number.integer {
   color: #009999;
 }
 /* Literal.Number.Integer */
-.mo {
+.mo, .literal.number.oct {
   color: #009999;
 }
 /* Literal.Number.Oct */
-.sb {
+.sb, .literal.string.backtick {
   color: #d01040;
 }
 /* Literal.String.Backtick */
-.sc {
+.sc, .literal.strong.char {
   color: #d01040;
 }
 /* Literal.String.Char */
-.sd {
+.sd, .literal.string.doc {
   color: #d01040;
 }
 /* Literal.String.Doc */
-.s2 {
+.s2, .literal.string.double {
   color: #d01040;
 }
 /* Literal.String.Double */
-.se {
+.se, .literal.string.escape {
   color: #d01040;
 }
 /* Literal.String.Escape */
-.sh {
+.sh, .literal.string.heredoc {
   color: #d01040;
 }
 /* Literal.String.Heredoc */
-.si {
+.si, .literal.string.interpol {
   color: #d01040;
 }
 /* Literal.String.Interpol */
-.sx {
+.sx, .literal.string.other {
   color: #d01040;
 }
 /* Literal.String.Other */
-.sr {
+.sr, .literal.string.regex {
   color: #009926;
 }
 /* Literal.String.Regex */
-.s1 {
+.s1, .literal.string.single {
   color: #d01040;
 }
 /* Literal.String.Single */
-.ss {
+.ss, .literal.string.symbol {
   color: #990073;
 }
 /* Literal.String.Symbol */
-.bp {
+.bp, .name.builtin.pseudo {
   color: #999999;
 }
 /* Name.Builtin.Pseudo */
-.vc {
+.vc, .name.variable.class {
   color: #008080;
 }
 /* Name.Variable.Class */
-.vg {
+.vg, .name.variable.global {
   color: #008080;
 }
 /* Name.Variable.Global */
-.vi {
+.vi, .name.variable.instance {
   color: #008080;
 }
 /* Name.Variable.Instance */
-.il {
+.il, .literal.number.integer.long {
   color: #009999;
 }
 /* Literal.Number.Integer.Long */


### PR DESCRIPTION
Hugo allows us to use [multiple formats](https://gohugo.io/content-management/formats/) in addition
to Markdown. This theme assumes Markdown but reStructuredText (rST) works quite nicely with one
exception: code. Fix some issues here that are necessary to get basic syntax highlighting working.