### PR TITLE
Fixed listing of posts on index page bug

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,7 +13,9 @@
                 <div class="page-heading">{{ i18n "latestPosts" }}</div>
                 <ul>
                     {{ range (first $latestpostscount (where .Data.Pages.ByPublishDate.Reverse "Section" "blog")) }}
-                        {{ partial "li.html" . }}
+                        {{ range .Pages }}
+                            {{ partial "li.html" . }}
+                        {{ end }}
                     {{ end }}
                     {{ if gt $totalpostscount $latestpostscount }}
                         {{ range where .Site.Menus.main "Identifier" "blog" }}


### PR DESCRIPTION
Fixed listing of posts on the index page - blog folder was being listed instead of contents of the blog folder i.e the individual blog items themselves.


**Before -**
![Screenshot 2020-08-04 at 10 06 22 PM](https://user-images.githubusercontent.com/11946350/89320366-062d5600-d69f-11ea-81e0-9f82a7973399.png)

**After -**
![Screenshot 2020-08-04 at 10 06 33 PM](https://user-images.githubusercontent.com/11946350/89320441-1d6c4380-d69f-11ea-96fb-50dc3adebcbb.png)


