### PR TITLE
Only show "Latest Posts" on homepage if needed

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,7 +8,9 @@
                 </div>
             {{ end }}
 
-            <div class="page-heading">{{ i18n "latestPosts" }}</div>
+            {{ if isset .Site.Params "latestpostscount" }}
+                <div class="page-heading">{{ i18n "latestPosts" }}</div>
+            {{ end }}
 
             {{ if isset .Site.Params "paginate" }}
                 <div style="padding-bottom:20px;">


### PR DESCRIPTION
Uses the "latestpostscount" param to make the decision. Hides the "Latest Posts" header on the index page if the "latestpostscount" param is unset.